### PR TITLE
fix: During setup.sh, pb_hooks/pages/assets now exists before running build command

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -130,6 +130,9 @@ echo "Running initial build..."
 
 cd ..
 
+# Create pb_hooks/pages/assets directory (necessary for the build)
+mkdir -p server/pb_hooks/pages/assets
+
 # Run the build script
 npm run build -w scripts
 


### PR DESCRIPTION
This PR adds a step to the setup.sh command to create the assets directory before running the build command.